### PR TITLE
Equate if a node is a property even if the value is a DisplayObject.

### DIFF
--- a/src/hml/xml/adapters/FlashAdapter.hx
+++ b/src/hml/xml/adapters/FlashAdapter.hx
@@ -94,7 +94,11 @@ class DisplayObjectAdapter extends BaseEventDispatcherAdapter {
 
 class DisplayObjectWithMetaWriter extends BaseNodeWithMetaWriter {
 	override function child(node:Node, scope:String, child:Node, method:Array<String>, assign = false):Void {
-		method.push('$scope.addChild(${universalGet(child)});');
+		if (!assign) {
+			method.push('$scope.addChild(${universalGet(child)});');
+		} else {
+			super.child(node, scope, child, method, assign);
+		}
 	}
 }
 


### PR DESCRIPTION
The case:

**Haxe:**

``` haxe
class AssetBackground implements GroundDecorator {
    public var asset: DisplayObject;
}
```

**XML:**

``` xml
<AssetBackground xmlns="org.aswing">
    <asset>
        <JButton width="50" height="50" text="'Button!!!'"/>
    </asset>
</AssetBackground>
```

**Result:** it generates 

``` haxe
asset.addChild(someProperty);
```

**Expected:**

``` haxe
asset = someProperty;
```
