### PR TITLE
Fixed generic nulling

### DIFF
--- a/src/hml/xml/typeResolver/DefaultHaxeTypeResolver.hx
+++ b/src/hml/xml/typeResolver/DefaultHaxeTypeResolver.hx
@@ -33,7 +33,6 @@ class DefaultHaxeTypeResolver implements IHaxeTypeResolver<Node, Type> {
                     if (types != null) {
                         while (params.length > 0) params.pop();
                         for (s in types) params.push(s);
-                        node.generic = null;
                     }
                 case _:
             }


### PR DESCRIPTION
Removed nulling of `node.generic` in `DefaultHaxeTypeResolver.getNativeType` as it's later used in `DefaultNodeWritter.nativeTypeString`
